### PR TITLE
Integrate mobile mcp as microservice

### DIFF
--- a/BACKEND_HANDOFF.md
+++ b/BACKEND_HANDOFF.md
@@ -21,6 +21,43 @@ This document is the single place where agents leave status for each other. Alwa
 
 ---
 
+## Handoff #20 — Mobile MCP Microservice Integration (2025-11-11)
+
+- **What I am doing**: Integrating the upstream `mobile-mcp` runtime as an Encore microservice to replace the WebDriverIO adapters for device I/O. Backend now exposes HTTPS + SSE endpoints for screenshot, accessibility tree, tap, type, swipe, long press, launch app, press button, and screen-size tools; agent workers use new Mobile MCP adapters.
+
+- **What is pending**:
+  - [x] Code: Mobile MCP service scaffolding, session registry, Encore endpoints, AWS connector stub
+  - [x] Code: Agent session/perception/input/device-info/navigation/app-lifecycle adapters targeting the microservice
+  - [x] Code: Updated orchestrator wiring to use Mobile MCP stack
+  - [x] Tests: Added Vitest coverage for session and input adapters (mocked client)
+  - [ ] Docs: Broader architecture docs + API documentation refresh (partial update in `backend/mobile-mcp/ARCHITECTURE.md`)
+  - [ ] Manual run: Needs real-device validation once AWS Device Farm credentials are configured
+
+- **What I plan to do next**:
+  - Flesh out AWS MCP bridge integration once credentials are available (currently supports static device fallback)
+  - Expand test suite to cover navigation + app lifecycle adapters
+  - Document operational runbook for the mobile MCP service (env vars, failure modes)
+
+- **Modules I am touching**:
+  - `backend/mobile-mcp/` (new service)
+  - `backend/agent/adapters/mobile-mcp/` (new adapter family + tests)
+  - `backend/agent/orchestrator/worker.ts` (port wiring)
+  - `backend/config/env.ts`, `backend/db/migrations/010_mobile_mcp_sessions.up.sql`
+
+- **Work status rating (out of 5)**: 4
+
+- **Related docs**:
+  - `backend/mobile-mcp/ARCHITECTURE.md`
+  - `.cursor/rules/backend_coding_rules.mdc` (Mobile MCP tooling references)
+
+- **Notes for next agent**:
+  - Encore client regeneration (`bun run gen`) required so the new `mobileMcp` client is available at `~encore/clients`.
+  - Configure `MOBILE_MCP_AWS_MCP_URL` and bearer token to activate AWS Device Farm bridge; otherwise the service uses the local static device ID fallback.
+  - Mobile MCP adapters currently stub package management/idle detection via fakes; replace with real implementations once MCP exposes those primitives.
+  - Endpoints stream structured SSE events—use `encore-mcp.call_endpoint` or the new SSE path during QA.
+
+---
+
 ## Handoff #19 — Port Management Simplification (2025-11-07)
 
 - **What I am doing**: ✅ **COMPLETED** - Simplified port management to use `.env` as single source of truth per founder rules. Removed `backend/scripts/port-coordinator.mjs` which added unnecessary complexity and violated architecture principles.

--- a/backend/agent/adapters/mobile-mcp/__tests__/input-actions.adapter.test.ts
+++ b/backend/agent/adapters/mobile-mcp/__tests__/input-actions.adapter.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { MobileMcpInputActionsAdapter } from "../input-actions.adapter";
+import type { MobileMcpSessionState } from "../session.adapter";
+
+vi.mock("~encore/clients", () => {
+  return {
+    mobileMcp: {
+      tap: vi.fn(async () => undefined),
+      swipe: vi.fn(async () => undefined),
+      longPress: vi.fn(async () => undefined),
+      typeText: vi.fn(async () => undefined),
+    },
+  };
+});
+
+const context: MobileMcpSessionState = {
+  sessionId: "session-123",
+  runId: "run-xyz",
+  deviceId: "device-456",
+  devicePlatform: "android",
+  runtimeContext: {
+    deviceRuntimeContextId: "session-123",
+    deviceId: "device-456",
+    capabilitiesEcho: {},
+    healthProbeStatus: "HEALTHY",
+  },
+};
+
+const getMockClient = async () => {
+  const clients = await import("~encore/clients");
+  return clients.mobileMcp;
+};
+
+describe("MobileMcpInputActionsAdapter", () => {
+  beforeEach(async () => {
+    const client = await getMockClient();
+    client.tap.mockClear();
+    client.swipe.mockClear();
+    client.longPress.mockClear();
+    client.typeText.mockClear();
+  });
+
+  test("performTap forwards coordinates to Mobile MCP", async () => {
+    const adapter = new MobileMcpInputActionsAdapter(() => context);
+    await adapter.performTap(10, 20);
+    const client = await getMockClient();
+    expect(client.tap).toHaveBeenCalledWith({ sessionId: "session-123", x: 10, y: 20 });
+  });
+
+  test("performSwipe forwards swipe arguments", async () => {
+    const adapter = new MobileMcpInputActionsAdapter(() => context);
+    await adapter.performSwipe(0, 0, 100, 200, 300);
+    const client = await getMockClient();
+    expect(client.swipe).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      startX: 0,
+      startY: 0,
+      endX: 100,
+      endY: 200,
+      durationMs: 300,
+    });
+  });
+
+  test("performLongPress forwards duration and coordinates", async () => {
+    const adapter = new MobileMcpInputActionsAdapter(() => context);
+    await adapter.performLongPress(5, 6, 700);
+    const client = await getMockClient();
+    expect(client.longPress).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      x: 5,
+      y: 6,
+      durationMs: 700,
+    });
+  });
+
+  test("performTextInput sends text payload", async () => {
+    const adapter = new MobileMcpInputActionsAdapter(() => context);
+    await adapter.performTextInput("hello");
+    const client = await getMockClient();
+    expect(client.typeText).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      text: "hello",
+    });
+  });
+});

--- a/backend/agent/adapters/mobile-mcp/__tests__/session.adapter.test.ts
+++ b/backend/agent/adapters/mobile-mcp/__tests__/session.adapter.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { MobileMcpSessionAdapter } from "../session.adapter";
+
+vi.mock("~encore/clients", () => {
+  return {
+    mobileMcp: {
+      startSession: vi.fn(async () => ({
+        sessionId: "session-123",
+        runId: "run-abc",
+        deviceId: "device-xyz",
+        devicePlatform: "android" as const,
+      })),
+      stopSession: vi.fn(async () => undefined),
+    },
+  };
+});
+
+const getMockClient = async () => {
+  const clients = await import("~encore/clients");
+  return clients.mobileMcp;
+};
+
+describe("MobileMcpSessionAdapter", () => {
+  beforeEach(async () => {
+    const client = await getMockClient();
+    client.startSession.mockClear();
+    client.stopSession.mockClear();
+  });
+
+  test("ensureDevice starts a session once and caches runtime context", async () => {
+    const adapter = new MobileMcpSessionAdapter();
+
+    const runtimeContext = await adapter.ensureDevice({
+      platformName: "Android",
+      deviceName: "pixel",
+      platformVersion: "14",
+      appiumServerUrl: "http://localhost:4723",
+      appPackage: "com.example.app",
+    });
+
+    expect(runtimeContext.deviceRuntimeContextId).toBe("session-123");
+    expect(runtimeContext.deviceId).toBe("device-xyz");
+    expect(runtimeContext.capabilitiesEcho).toMatchObject({
+      platform: "android",
+      appPackage: "com.example.app",
+    });
+
+    const client = await getMockClient();
+    expect(client.startSession).toHaveBeenCalledTimes(1);
+
+    const secondCall = await adapter.ensureDevice({
+      platformName: "Android",
+      deviceName: "pixel",
+      platformVersion: "14",
+      appiumServerUrl: "http://localhost:4723",
+    });
+
+    expect(secondCall).toBe(runtimeContext);
+    expect(client.startSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("closeSession stops the active session", async () => {
+    const adapter = new MobileMcpSessionAdapter();
+    await adapter.ensureDevice({
+      platformName: "Android",
+      deviceName: "pixel",
+      platformVersion: "14",
+      appiumServerUrl: "http://localhost:4723",
+    });
+
+    const client = await getMockClient();
+    expect(client.stopSession).not.toHaveBeenCalled();
+
+    await adapter.closeSession();
+    expect(client.stopSession).toHaveBeenCalledWith({ sessionId: "session-123" });
+  });
+});

--- a/backend/agent/adapters/mobile-mcp/app-lifecycle.adapter.ts
+++ b/backend/agent/adapters/mobile-mcp/app-lifecycle.adapter.ts
@@ -1,0 +1,52 @@
+import type { ApplicationForegroundContext } from "../../domain/entities";
+import type { AppLifecycleBudget, AppLifecyclePort } from "../../ports/appium/app-lifecycle.port";
+import { getMobileMcpClient } from "./client";
+import type { MobileMcpSessionState } from "./session.adapter";
+
+/**
+ * MobileMcpAppLifecycleAdapter implements AppLifecyclePort using Mobile MCP endpoints.
+ * PURPOSE: Launches and restarts applications within the Mobile MCP session.
+ */
+export class MobileMcpAppLifecycleAdapter implements AppLifecyclePort {
+  private lastForegroundPackage: string | null = null;
+
+  constructor(private readonly contextProvider: () => MobileMcpSessionState | null) {}
+
+  private get context(): MobileMcpSessionState {
+    const ctx = this.contextProvider();
+    if (!ctx) {
+      throw new Error("Mobile MCP session not initialized");
+    }
+    return ctx;
+  }
+
+  async launchApp(packageId: string, _budget: AppLifecycleBudget): Promise<ApplicationForegroundContext> {
+    const client = await getMobileMcpClient();
+    await client.launchApp({
+      sessionId: this.context.sessionId,
+      packageName: packageId,
+    });
+
+    this.lastForegroundPackage = packageId;
+
+    return {
+      currentPackageId: packageId,
+      currentActivityName: "unknown",
+      appBroughtToForegroundTimestamp: new Date().toISOString(),
+    };
+  }
+
+  async restartApp(packageId: string, budget: AppLifecycleBudget): Promise<boolean> {
+    const client = await getMobileMcpClient();
+    await client.pressButton({
+      sessionId: this.context.sessionId,
+      button: "HOME",
+    });
+    await this.launchApp(packageId, budget);
+    return true;
+  }
+
+  async getCurrentApp(): Promise<string> {
+    return this.lastForegroundPackage ?? "unknown";
+  }
+}

--- a/backend/agent/adapters/mobile-mcp/client.ts
+++ b/backend/agent/adapters/mobile-mcp/client.ts
@@ -1,0 +1,12 @@
+/**
+ * getMobileMcpClient lazily loads the Encore-generated Mobile MCP client.
+ * PURPOSE: Avoids circular imports and delays loading until the first call.
+ */
+export async function getMobileMcpClient() {
+  const clients = await import("~encore/clients");
+  const client = clients.mobileMcp;
+  if (!client) {
+    throw new Error("mobileMcp client is not available from ~encore/clients");
+  }
+  return client;
+}

--- a/backend/agent/adapters/mobile-mcp/device-info.adapter.ts
+++ b/backend/agent/adapters/mobile-mcp/device-info.adapter.ts
@@ -1,0 +1,39 @@
+import type { DeviceInfoPort } from "../../ports/appium/device-info.port";
+import { getMobileMcpClient } from "./client";
+import type { MobileMcpSessionState } from "./session.adapter";
+
+/**
+ * MobileMcpDeviceInfoAdapter implements DeviceInfoPort through Mobile MCP APIs.
+ * PURPOSE: Provides screen dimension queries required by the perception pipeline.
+ */
+export class MobileMcpDeviceInfoAdapter implements DeviceInfoPort {
+  constructor(private readonly contextProvider: () => MobileMcpSessionState | null) {}
+
+  private get context(): MobileMcpSessionState {
+    const ctx = this.contextProvider();
+    if (!ctx) {
+      throw new Error("Mobile MCP session not initialized");
+    }
+    return ctx;
+  }
+
+  async getScreenDimensions(): Promise<{ widthPx: number; heightPx: number }> {
+    const client = await getMobileMcpClient();
+    const response = await client.fetchScreenDimensions({
+      sessionId: this.context.sessionId,
+    });
+    return {
+      widthPx: response.widthPx,
+      heightPx: response.heightPx,
+    };
+  }
+
+  async isDeviceReady(): Promise<boolean> {
+    try {
+      await this.getScreenDimensions();
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+}

--- a/backend/agent/adapters/mobile-mcp/input-actions.adapter.ts
+++ b/backend/agent/adapters/mobile-mcp/input-actions.adapter.ts
@@ -1,0 +1,64 @@
+import type { InputActionsPort } from "../../ports/appium/input-actions.port";
+import { getMobileMcpClient } from "./client";
+import type { MobileMcpSessionState } from "./session.adapter";
+
+/**
+ * MobileMcpInputActionsAdapter maps InputActionsPort methods to Mobile MCP tools.
+ * PURPOSE: Executes tap, swipe, long press, and text input via the microservice.
+ */
+export class MobileMcpInputActionsAdapter implements InputActionsPort {
+  constructor(private readonly contextProvider: () => MobileMcpSessionState | null) {}
+
+  private get context(): MobileMcpSessionState {
+    const ctx = this.contextProvider();
+    if (!ctx) {
+      throw new Error("Mobile MCP session not initialized");
+    }
+    return ctx;
+  }
+
+  async performTap(x: number, y: number): Promise<void> {
+    const client = await getMobileMcpClient();
+    await client.tap({
+      sessionId: this.context.sessionId,
+      x,
+      y,
+    });
+  }
+
+  async performSwipe(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    durationMs: number,
+  ): Promise<void> {
+    const client = await getMobileMcpClient();
+    await client.swipe({
+      sessionId: this.context.sessionId,
+      startX,
+      startY,
+      endX,
+      endY,
+      durationMs,
+    });
+  }
+
+  async performLongPress(x: number, y: number, durationMs: number): Promise<void> {
+    const client = await getMobileMcpClient();
+    await client.longPress({
+      sessionId: this.context.sessionId,
+      x,
+      y,
+      durationMs,
+    });
+  }
+
+  async performTextInput(text: string): Promise<void> {
+    const client = await getMobileMcpClient();
+    await client.typeText({
+      sessionId: this.context.sessionId,
+      text,
+    });
+  }
+}

--- a/backend/agent/adapters/mobile-mcp/navigation.adapter.ts
+++ b/backend/agent/adapters/mobile-mcp/navigation.adapter.ts
@@ -1,0 +1,35 @@
+import type { NavigationPort } from "../../ports/appium/navigation.port";
+import { getMobileMcpClient } from "./client";
+import type { MobileMcpSessionState } from "./session.adapter";
+
+/**
+ * MobileMcpNavigationAdapter implements navigation operations through Mobile MCP.
+ * PURPOSE: Provides back/home navigation using the microservice tools.
+ */
+export class MobileMcpNavigationAdapter implements NavigationPort {
+  constructor(private readonly contextProvider: () => MobileMcpSessionState | null) {}
+
+  private get context(): MobileMcpSessionState {
+    const ctx = this.contextProvider();
+    if (!ctx) {
+      throw new Error("Mobile MCP session not initialized");
+    }
+    return ctx;
+  }
+
+  async performBack(): Promise<void> {
+    const client = await getMobileMcpClient();
+    await client.pressButton({
+      sessionId: this.context.sessionId,
+      button: "BACK",
+    });
+  }
+
+  async pressHome(): Promise<void> {
+    const client = await getMobileMcpClient();
+    await client.pressButton({
+      sessionId: this.context.sessionId,
+      button: "HOME",
+    });
+  }
+}

--- a/backend/agent/adapters/mobile-mcp/perception.adapter.ts
+++ b/backend/agent/adapters/mobile-mcp/perception.adapter.ts
@@ -1,0 +1,40 @@
+import type { ScreenshotData, UiHierarchyData } from "../../domain/perception";
+import type { PerceptionPort } from "../../ports/appium/perception.port";
+import { getMobileMcpClient } from "./client";
+import type { MobileMcpSessionState } from "./session.adapter";
+
+/**
+ * MobileMcpPerceptionAdapter implements PerceptionPort using Mobile MCP APIs.
+ * PURPOSE: Captures screenshots and accessibility trees through the microservice.
+ */
+export class MobileMcpPerceptionAdapter implements PerceptionPort {
+  constructor(private readonly contextProvider: () => MobileMcpSessionState | null) {}
+
+  private get context(): MobileMcpSessionState {
+    const ctx = this.contextProvider();
+    if (!ctx) {
+      throw new Error("Mobile MCP session not initialized");
+    }
+    return ctx;
+  }
+
+  async captureScreenshot(): Promise<ScreenshotData> {
+    const client = await getMobileMcpClient();
+    const response = await client.captureScreenshot({ sessionId: this.context.sessionId });
+    return {
+      base64Image: response.base64Image,
+      format: response.mimeType === "image/jpeg" ? "jpg" : "png",
+      widthPx: response.widthPx,
+      heightPx: response.heightPx,
+    };
+  }
+
+  async dumpUiHierarchy(): Promise<UiHierarchyData> {
+    const client = await getMobileMcpClient();
+    const response = await client.fetchAccessibilityTree({ sessionId: this.context.sessionId });
+    return {
+      xmlContent: response.xml,
+      captureTimestampMs: new Date(response.capturedAtIso).getTime(),
+    };
+  }
+}

--- a/backend/agent/adapters/mobile-mcp/session.adapter.ts
+++ b/backend/agent/adapters/mobile-mcp/session.adapter.ts
@@ -1,0 +1,81 @@
+import type { DeviceRuntimeContext } from "../../domain/entities";
+import type { DeviceConfiguration, SessionPort } from "../../ports/appium/session.port";
+import { getMobileMcpClient } from "./client";
+
+export interface MobileMcpSessionState {
+  sessionId: string;
+  runId: string;
+  deviceId: string;
+  devicePlatform: "android" | "ios";
+  runtimeContext: DeviceRuntimeContext;
+}
+
+/**
+ * MobileMcpSessionAdapter implements SessionPort using the Mobile MCP microservice.
+ * PURPOSE: Orchestrates session lifecycle and exposes deterministic runtime context metadata.
+ */
+export class MobileMcpSessionAdapter implements SessionPort {
+  private state: MobileMcpSessionState | null = null;
+
+  /**
+   * ensureDevice starts (or reuses) a Mobile MCP session and returns a runtime context.
+   * PURPOSE: Provides the agent orchestrator with a deterministic session identifier.
+   */
+  async ensureDevice(config: DeviceConfiguration): Promise<DeviceRuntimeContext> {
+    if (this.state) {
+      return this.state.runtimeContext;
+    }
+
+    const mobileMcp = await getMobileMcpClient();
+    const platformName = config.platformName?.toLowerCase() === "ios" ? "ios" : "android";
+    const response = await mobileMcp.startSession({
+      platform: platformName,
+      runId: config.deviceName ?? undefined,
+      deviceAlias: config.deviceName ?? undefined,
+      appPackageId: config.appPackage ?? undefined,
+    });
+
+    const runtimeContext: DeviceRuntimeContext = {
+      deviceRuntimeContextId: response.sessionId,
+      deviceId: response.deviceId,
+      capabilitiesEcho: {
+        platform: platformName,
+        appPackage: config.appPackage ?? null,
+      },
+      healthProbeStatus: "HEALTHY",
+    };
+
+    this.state = {
+      sessionId: response.sessionId,
+      runId: response.runId ?? config.deviceName ?? "unknown",
+      deviceId: response.deviceId,
+      devicePlatform: response.devicePlatform,
+      runtimeContext,
+    };
+
+    return runtimeContext;
+  }
+
+  /**
+   * closeSession terminates the active Mobile MCP session if present.
+   * PURPOSE: Releases device resources when the agent finishes execution.
+   */
+  async closeSession(): Promise<void> {
+    if (!this.state) {
+      return;
+    }
+    const mobileMcp = await getMobileMcpClient();
+    await mobileMcp.stopSession({
+      sessionId: this.state.sessionId,
+    });
+    this.state = null;
+  }
+
+  /**
+   * getContext exposes the cached session state for other adapters.
+   * PURPOSE: Enables perception/input adapters to re-use the established session.
+   */
+  getContext(): MobileMcpSessionState | null {
+    return this.state;
+  }
+}

--- a/backend/agent/nodes/types.ts
+++ b/backend/agent/nodes/types.ts
@@ -8,6 +8,8 @@ import type { DeviceInfoPort } from "../ports/appium/device-info.port";
 import type { StoragePort } from "../ports/storage";
 import type { LLMPort } from "../ports/llm";
 import type { GraphPort } from "../ports/graph";
+import type { InputActionsPort } from "../ports/appium/input-actions.port";
+import type { NavigationPort } from "../ports/appium/navigation.port";
 
 /**
  * AgentNodeName enumerates all nodes available in the agent execution graph.
@@ -95,6 +97,8 @@ export interface AgentPorts {
   packageManagerPort: PackageManagerPort;
   perceptionPort: PerceptionPort;
   deviceInfoPort: DeviceInfoPort;
+  inputActionsPort: InputActionsPort;
+  navigationPort: NavigationPort;
   storagePort: StoragePort;
   llmPort: LLMPort;
   graphPort: GraphPort;

--- a/backend/config/env.ts
+++ b/backend/config/env.ts
@@ -56,6 +56,26 @@ export const env = cleanEnv(process.env, {
     default: 1,
     desc: "Expected number of unique screens discovered for deterministic testing with default app config",
   }),
+  MOBILE_MCP_AWS_MCP_URL: str({
+    default: "",
+    desc: "Optional SSE endpoint URL for the AWS MCP Device Farm bridge",
+  }),
+  MOBILE_MCP_AWS_MCP_BEARER_TOKEN: str({
+    default: "",
+    desc: "Optional bearer token used when authenticating against the AWS MCP bridge",
+  }),
+  MOBILE_MCP_DEVICE_POOL_ARN: str({
+    default: "",
+    desc: "Device pool ARN used when requesting AWS Device Farm sessions",
+  }),
+  MOBILE_MCP_PROJECT_ARN: str({
+    default: "",
+    desc: "Project ARN used when requesting AWS Device Farm sessions",
+  }),
+  MOBILE_MCP_STATIC_DEVICE_ID: str({
+    default: "",
+    desc: "Fallback device identifier for local development when AWS Device Farm is unavailable",
+  }),
 });
 
 export const {
@@ -71,4 +91,9 @@ export const {
   ENABLE_GRAPH_STREAM,
   XSTATE_INSPECTOR_ENABLED,
   EXPECTED_UNIQUE_SCREENS_DISCOVERED,
+  MOBILE_MCP_AWS_MCP_URL,
+  MOBILE_MCP_AWS_MCP_BEARER_TOKEN,
+  MOBILE_MCP_DEVICE_POOL_ARN,
+  MOBILE_MCP_PROJECT_ARN,
+  MOBILE_MCP_STATIC_DEVICE_ID,
 } = env;

--- a/backend/db/migrations/010_mobile_mcp_sessions.up.sql
+++ b/backend/db/migrations/010_mobile_mcp_sessions.up.sql
@@ -1,0 +1,21 @@
+-- Create table for tracking Mobile MCP sessions orchestrated by the backend.
+-- PURPOSE: Persist session metadata so Encore workers can resume or audit Device Farm sessions.
+CREATE TABLE IF NOT EXISTS mobile_mcp_sessions (
+    mobile_mcp_session_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    device_id TEXT NOT NULL,
+    device_platform TEXT NOT NULL,
+    device_farm_job_arn TEXT,
+    appium_endpoint_url TEXT,
+    mcp_session_token TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    last_heartbeat_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mobile_mcp_sessions_run
+    ON mobile_mcp_sessions (run_id);
+
+CREATE INDEX IF NOT EXISTS idx_mobile_mcp_sessions_status
+    ON mobile_mcp_sessions (status);

--- a/backend/mobile-mcp/ARCHITECTURE.md
+++ b/backend/mobile-mcp/ARCHITECTURE.md
@@ -1,0 +1,82 @@
+## Mobile MCP Microservice Architecture
+
+### Purpose
+- Run the upstream `mobile-mcp` server inside Encore as an isolated microservice for device I/O.
+- Bridge AWS Device Farm sessions through the existing Encore MCP and AWS MCP utilities.
+- Expose deterministic HTTPS endpoints plus SSE streams for the core MCP tools (`screenshot`, `a11y_tree`, `tap`, `type`, `swipe`, `launch_app`).
+
+### High-Level Components
+- **MobileMcpSessionRegistry** — Tracks active Device Farm sessions keyed by `runId` and manages lifecycle (start, keep-alive, teardown).
+- **AwsDeviceFarmConnector** — Uses the AWS MCP tool to allocate devices, resolve Appium endpoints, and fetch credentials required by `mobile-mcp`.
+- **MobileMcpRuntime** — Spawns the `mobile-mcp` process (or reuses in-process SDK) and exposes MCP tool invocation APIs.
+- **MobileMcpController** — Encore service layer exposing HTTPS APIs and SSE stream for tool execution events.
+- **AgentAdapters** — New adapters in `backend/agent/adapters/mobile-mcp/` that implement the existing Appium-oriented ports by calling Encore-generated clients for this microservice.
+
+### Service Boundaries
+- **Input**: Requests from agent orchestrator (Encore client) identifying the run, desired tool, and tool arguments.
+- **Output**: Structured responses (or streams) mirroring MCP tool payloads, plus translated domain types (`ScreenshotData`, `DeviceRuntimeContext`, etc.).
+- **External Dependencies**: AWS Device Farm via AWS MCP, the upstream `mobile-mcp` npm package, existing Encore DB for persistence of session metadata.
+
+### API Surface (Encore)
+- `POST /mobile-mcp/session/start` — Start or reuse a Device Farm session. Returns `MobileMcpSession` (encapsulates AWS session ARN, Appium endpoint, MCP channel IDs).
+- `DELETE /mobile-mcp/session/:sessionId` — Tear down an active session and release AWS resources.
+- `POST /mobile-mcp/session/:sessionId/tools/:toolName` — Invoke a specific MCP tool and return the final result payload.
+- `GET /mobile-mcp/session/:sessionId/tools/:toolName/stream` — SSE stream forwarding incremental MCP tool events (progress, partial outputs, errors).
+- Convenience endpoints mapping to core Mobile MCP tools:
+  - `POST .../tools/mobile_take_screenshot`
+  - `POST .../tools/mobile_list_elements_on_screen`
+  - `POST .../tools/mobile_get_screen_size`
+  - `POST .../tools/mobile_click_on_screen_at_coordinates`
+  - `POST .../tools/mobile_long_press_on_screen_at_coordinates`
+  - `POST .../tools/mobile_swipe_on_screen`
+  - `POST .../tools/mobile_type_keys`
+  - `POST .../tools/mobile_press_button`
+  - `POST .../tools/mobile_launch_app`
+
+### Data Contracts
+- `MobileMcpSession` — `{ sessionId, runId, deviceFarmJobArn, appiumEndpointUrl, mcpSessionToken, lastHeartbeatIso }`.
+- `ToolInvocationRequest` — `{ toolInput: Record<string, unknown>, correlationId, runId }`.
+- `ToolInvocationResult` — `{ status: "SUCCEEDED" | "FAILED", payload, error? }`.
+- `ToolInvocationEvent` (SSE) — `{ correlationId, stage: "started" | "progress" | "completed" | "failed", payload }`.
+
+### AWS Device Farm Flow
+1. **start**: `AwsDeviceFarmConnector` calls AWS MCP tool `device_farm.start_session`.
+2. Extract Appium endpoint + credentials, persist in registry.
+3. Configure `MobileMcpRuntime` with Device Farm endpoint; launch/attach to `mobile-mcp`.
+4. Return `sessionId` + device metadata to callers.
+5. **stop**: Call `device_farm.stop_session` via AWS MCP and kill runtime process.
+
+### MCP Tool Invocation Flow
+1. Agent adapter calls `POST /tools/:toolName` with `runId` + tool args.
+2. Controller fetches session from registry, forwards request to `MobileMcpRuntime`.
+3. Runtime sends `callTool` request to `mobile-mcp`.
+4. Streaming events (if requested) are proxied over SSE; final payload persisted for replay if required.
+5. Controller translates final response to domain DTOs (e.g., base64 screenshot to `ScreenshotData`).
+
+### Agent Integration Plan
+- Introduce `backend/agent/adapters/mobile-mcp/` with adapters implementing `SessionPort`, `PerceptionPort`, `InputActionsPort`, etc.
+- Update agent composition root to choose Mobile MCP adapters when backend configuration toggles `DEVICE_PROVIDER=mobile-mcp`.
+- Ensure adapters translate Encore DTOs to domain types without leaking `mobile-mcp` specifics.
+
+### Observability & Logging
+- All Encore handlers use `log.with({ module: "mobile-mcp", actor: "...", runId })`.
+- Stream events include `correlationId` for traceability.
+- Failures bubble up as `APIError` with canonical error codes (`device_unavailable`, `tool_failed`, `session_expired`).
+
+### Persistence
+- Create `mobile_mcp_sessions` table storing session metadata and heartbeat timestamps for replay/auditing.
+- Optionally persist tool invocation history for debugging (future iteration).
+
+### Testing Strategy
+- Unit tests for registry + runtime using fake Mobile MCP client.
+- Integration test that simulates tool invocation using stubbed AWS connector.
+- SSE smoke test verifying stream order and terminal events.
+- Agent integration test hitting the new Encore client to perform `screenshot` + `tap` flows using fakes.
+
+### Rollout Plan
+1. Scaffold Encore service + DTOs + session registry.
+2. Wire AWS connector with configuration from `config/env.ts`.
+3. Implement adapters and update agent dependency injection.
+4. Write tests + documentation.
+5. Validate via encore-mcp call endpoints + QA smoke tests.
+

--- a/backend/mobile-mcp/aws-device-farm-connector.ts
+++ b/backend/mobile-mcp/aws-device-farm-connector.ts
@@ -1,0 +1,230 @@
+import { Client } from "@modelcontextprotocol/sdk/client";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse";
+import { CallToolResultSchema, type CallToolResult } from "@modelcontextprotocol/sdk/types";
+import log from "encore.dev/log";
+
+import {
+  MOBILE_MCP_AWS_MCP_BEARER_TOKEN,
+  MOBILE_MCP_AWS_MCP_URL,
+  MOBILE_MCP_DEVICE_POOL_ARN,
+  MOBILE_MCP_PROJECT_ARN,
+  MOBILE_MCP_STATIC_DEVICE_ID,
+} from "../config/env";
+import type { MobilePlatformKind } from "./dto";
+
+/**
+ * DeviceFarmSessionDetails surfaces the metadata required to route traffic to the allocated device.
+ * PURPOSE: Shared contract between the connector and session registry.
+ */
+export interface DeviceFarmSessionDetails {
+  deviceId: string;
+  devicePlatform: MobilePlatformKind;
+  deviceFarmJobArn?: string;
+  appiumEndpointUrl?: string;
+  mcpSessionToken?: string;
+}
+
+/**
+ * DeviceFarmStartInput conveys the contextual information for provisioning a Device Farm session.
+ * PURPOSE: Keeps connector inputs minimal while supporting overrides per request.
+ */
+export interface DeviceFarmStartInput {
+  runId: string;
+  platform: MobilePlatformKind;
+  projectArnOverride?: string;
+  devicePoolArnOverride?: string;
+}
+
+/**
+ * AwsDeviceFarmConnector uses the AWS MCP bridge (when available) to allocate and release devices.
+ * PURPOSE: Centralizes Device Farm communication while offering a deterministic fallback for local dev.
+ */
+export class AwsDeviceFarmConnector {
+  private readonly logger = log.with({ module: "mobile-mcp", actor: "aws-connector" });
+
+  /**
+   * startSession provisions a device either through the AWS MCP bridge or a local fallback.
+   * PURPOSE: Supplies the runtime with a device identifier and related metadata.
+   */
+  async startSession(input: DeviceFarmStartInput): Promise<DeviceFarmSessionDetails> {
+    if (!MOBILE_MCP_AWS_MCP_URL) {
+      if (!MOBILE_MCP_STATIC_DEVICE_ID) {
+        throw new Error("MOBILE_MCP_STATIC_DEVICE_ID must be set when AWS MCP bridge is disabled");
+      }
+
+      this.logger.info("Using static device id fallback for Mobile MCP session", {
+        runId: input.runId,
+        platform: input.platform,
+      });
+
+      return {
+        deviceId: MOBILE_MCP_STATIC_DEVICE_ID,
+        devicePlatform: input.platform,
+      };
+    }
+
+    const url = new URL(MOBILE_MCP_AWS_MCP_URL);
+    const requestHeaders: Record<string, string> = {};
+    if (MOBILE_MCP_AWS_MCP_BEARER_TOKEN) {
+      requestHeaders.Authorization = `Bearer ${MOBILE_MCP_AWS_MCP_BEARER_TOKEN}`;
+    }
+
+    const transport = new SSEClientTransport(url, {
+      requestInit: {
+        headers: requestHeaders,
+      },
+    });
+
+    const client = new Client(
+      {
+        name: "mobile-mcp-aws-connector",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
+
+    try {
+      await client.connect(transport);
+
+      const argumentsPayload: Record<string, unknown> = {
+        runId: input.runId,
+        platform: input.platform,
+        projectArn: input.projectArnOverride || MOBILE_MCP_PROJECT_ARN || undefined,
+        devicePoolArn: input.devicePoolArnOverride || MOBILE_MCP_DEVICE_POOL_ARN || undefined,
+      };
+
+      const callResult = await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "device_farm.start_session",
+            arguments: argumentsPayload,
+          },
+        },
+        CallToolResultSchema,
+      );
+
+      const details = this.parseDeviceFarmSession(callResult, input.platform);
+      this.logger.info("AWS Device Farm session started", {
+        runId: input.runId,
+        deviceId: details.deviceId,
+        jobArn: details.deviceFarmJobArn,
+      });
+      return details;
+    } finally {
+      await transport.close();
+    }
+  }
+
+  /**
+   * stopSession tears down the Device Farm job when the AWS MCP bridge is configured.
+   * PURPOSE: Ensures allocated devices are released promptly after agent completion.
+   */
+  async stopSession(deviceFarmJobArn: string | undefined): Promise<void> {
+    if (!deviceFarmJobArn) {
+      this.logger.info("Skip Device Farm stop session because no job ARN was recorded");
+      return;
+    }
+
+    if (!MOBILE_MCP_AWS_MCP_URL) {
+      this.logger.info("AWS MCP bridge disabled, assuming static device cleanup handled externally", {
+        jobArn: deviceFarmJobArn,
+      });
+      return;
+    }
+
+    const url = new URL(MOBILE_MCP_AWS_MCP_URL);
+    const requestHeaders: Record<string, string> = {};
+    if (MOBILE_MCP_AWS_MCP_BEARER_TOKEN) {
+      requestHeaders.Authorization = `Bearer ${MOBILE_MCP_AWS_MCP_BEARER_TOKEN}`;
+    }
+
+    const transport = new SSEClientTransport(url, {
+      requestInit: {
+        headers: requestHeaders,
+      },
+    });
+
+    const client = new Client(
+      {
+        name: "mobile-mcp-aws-connector",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
+
+    try {
+      await client.connect(transport);
+      await client.request(
+        {
+          method: "tools/call",
+          params: {
+            name: "device_farm.stop_session",
+            arguments: {
+              jobArn: deviceFarmJobArn,
+            },
+          },
+        },
+        CallToolResultSchema,
+      );
+      this.logger.info("AWS Device Farm session stopped", { jobArn: deviceFarmJobArn });
+    } catch (err) {
+      this.logger.warn("Failed to stop AWS Device Farm session", { err, jobArn: deviceFarmJobArn });
+    } finally {
+      await transport.close();
+    }
+  }
+
+  private parseDeviceFarmSession(result: CallToolResult, platform: MobilePlatformKind): DeviceFarmSessionDetails {
+    for (const content of result.content ?? []) {
+      if (content.type === "text" && content.text) {
+        const parsed = this.tryParseJson(content.text.trim());
+        if (parsed && typeof parsed.deviceId === "string") {
+          return {
+            deviceId: parsed.deviceId,
+            devicePlatform: platform,
+            deviceFarmJobArn: typeof parsed.deviceFarmJobArn === "string" ? parsed.deviceFarmJobArn : undefined,
+            appiumEndpointUrl: typeof parsed.appiumEndpointUrl === "string" ? parsed.appiumEndpointUrl : undefined,
+            mcpSessionToken: typeof parsed.mcpSessionToken === "string" ? parsed.mcpSessionToken : undefined,
+          };
+        }
+      }
+
+      if (content.type === "resource" && content.resource && "text" in content.resource) {
+        const parsed = this.tryParseJson(String(content.resource.text));
+        if (parsed && typeof parsed.deviceId === "string") {
+          return {
+            deviceId: parsed.deviceId,
+            devicePlatform: platform,
+            deviceFarmJobArn: typeof parsed.deviceFarmJobArn === "string" ? parsed.deviceFarmJobArn : undefined,
+            appiumEndpointUrl: typeof parsed.appiumEndpointUrl === "string" ? parsed.appiumEndpointUrl : undefined,
+            mcpSessionToken: typeof parsed.mcpSessionToken === "string" ? parsed.mcpSessionToken : undefined,
+          };
+        }
+      }
+    }
+
+    throw new Error("Unable to parse AWS Device Farm session response");
+  }
+
+  private tryParseJson(value: string): Record<string, unknown> | null {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/backend/mobile-mcp/controller.ts
+++ b/backend/mobile-mcp/controller.ts
@@ -1,0 +1,194 @@
+import { api, APIError } from "encore.dev/api";
+import log from "encore.dev/log";
+
+import type {
+  AccessibilityTreeResponse,
+  LaunchAppRequest,
+  MobileMcpToolName,
+  LongPressRequest,
+  PressButtonRequest,
+  ScreenDimensionsResponse,
+  ScreenshotResponse,
+  StartSessionRequest,
+  StartSessionResponse,
+  SwipeRequest,
+  TapRequest,
+  ToolInvocationEvent,
+  ToolStreamHandshake,
+  ToolInvocationResult,
+  TypeRequest,
+} from "./dto";
+import { mobileMcpService } from "./service";
+
+interface StopSessionRequest {
+  sessionId: string;
+}
+
+interface ToolInvocationRequest {
+  sessionId: string;
+}
+
+const logger = log.with({ module: "mobile-mcp", actor: "controller" });
+
+export const startSession = api<StartSessionRequest, StartSessionResponse>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/start" },
+  async (req) => {
+    logger.info("HTTP start session request received", { runId: req.runId, platform: req.platform });
+    return await mobileMcpService.startSession(req);
+  },
+);
+
+export const stopSession = api<StopSessionRequest, void>(
+  { expose: true, method: "DELETE", path: "/mobile-mcp/sessions/:sessionId" },
+  async (req) => {
+    logger.info("HTTP stop session request received", { sessionId: req.sessionId });
+    await mobileMcpService.stopSession(req.sessionId);
+  },
+);
+
+export const captureScreenshot = api<ToolInvocationRequest, ScreenshotResponse>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_take_screenshot" },
+  async (req) => {
+    logger.info("HTTP screenshot request received", { sessionId: req.sessionId });
+    return await mobileMcpService.captureScreenshot(req.sessionId);
+  },
+);
+
+export const fetchAccessibilityTree = api<ToolInvocationRequest, AccessibilityTreeResponse>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_list_elements_on_screen" },
+  async (req) => {
+    logger.info("HTTP accessibility tree request received", { sessionId: req.sessionId });
+    return await mobileMcpService.fetchAccessibilityTree(req.sessionId);
+  },
+);
+
+export const fetchScreenDimensions = api<ToolInvocationRequest, ScreenDimensionsResponse>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_get_screen_size" },
+  async (req) => {
+    logger.info("HTTP screen size request received", { sessionId: req.sessionId });
+    return await mobileMcpService.getScreenDimensions(req.sessionId);
+  },
+);
+
+export const tap = api<ToolInvocationRequest & TapRequest, ToolInvocationResult>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_click_on_screen_at_coordinates" },
+  async (req) => {
+    logger.info("HTTP tap request received", { sessionId: req.sessionId, x: req.x, y: req.y });
+    return await mobileMcpService.performTap(req.sessionId, { x: req.x, y: req.y });
+  },
+);
+
+export const typeText = api<ToolInvocationRequest & TypeRequest, ToolInvocationResult>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_type_keys" },
+  async (req) => {
+    logger.info("HTTP type request received", { sessionId: req.sessionId, submit: req.submit });
+    return await mobileMcpService.performType(req.sessionId, { text: req.text, submit: req.submit });
+  },
+);
+
+export const swipe = api<ToolInvocationRequest & SwipeRequest, ToolInvocationResult>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_swipe_on_screen" },
+  async (req) => {
+    logger.info("HTTP swipe request received", {
+      sessionId: req.sessionId,
+      startX: req.startX,
+      startY: req.startY,
+      endX: req.endX,
+      endY: req.endY,
+    });
+    return await mobileMcpService.performSwipe(req.sessionId, {
+      startX: req.startX,
+      startY: req.startY,
+      endX: req.endX,
+      endY: req.endY,
+      durationMs: req.durationMs,
+    });
+  },
+);
+
+export const launchApp = api<ToolInvocationRequest & LaunchAppRequest, ToolInvocationResult>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_launch_app" },
+  async (req) => {
+    logger.info("HTTP launch app request received", { sessionId: req.sessionId, packageName: req.packageName });
+    return await mobileMcpService.launchApp(req.sessionId, { packageName: req.packageName });
+  },
+);
+
+export const pressButton = api<ToolInvocationRequest & PressButtonRequest, ToolInvocationResult>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_press_button" },
+  async (req) => {
+    logger.info("HTTP press button request received", { sessionId: req.sessionId, button: req.button });
+    return await mobileMcpService.pressButton(req.sessionId, { button: req.button });
+  },
+);
+
+export const longPress = api<ToolInvocationRequest & LongPressRequest, ToolInvocationResult>(
+  { expose: true, method: "POST", path: "/mobile-mcp/sessions/:sessionId/tools/mobile_long_press_on_screen_at_coordinates" },
+  async (req) => {
+    logger.info("HTTP long press request received", {
+      sessionId: req.sessionId,
+      x: req.x,
+      y: req.y,
+      durationMs: req.durationMs,
+    });
+    return await mobileMcpService.performLongPress(req.sessionId, {
+      x: req.x,
+      y: req.y,
+      durationMs: req.durationMs,
+    });
+  },
+);
+
+export const toolStream = api.streamOut<ToolStreamHandshake, ToolInvocationEvent>(
+  { expose: true, path: "/mobile-mcp/sessions/:sessionId/tools/stream" },
+  async (handshake, stream) => {
+    logger.info("SSE tool stream opened", {
+      sessionId: handshake.sessionId,
+      toolName: handshake.toolName,
+      correlationId: handshake.correlationId,
+    });
+
+    const sendEvent = async (event: ToolInvocationEvent): Promise<void> => {
+      await stream.send(event);
+    };
+
+    await sendEvent({
+      stage: "started",
+      summary: `Invoking ${handshake.toolName}`,
+      correlationId: handshake.correlationId,
+      payload: {
+        runId: handshake.runId,
+      },
+    });
+
+    try {
+      const result = await mobileMcpService.invokeGenericTool(handshake.sessionId, handshake.toolName, handshake.arguments ?? {});
+      await sendEvent({
+        stage: "completed",
+        summary: result.summary,
+        correlationId: handshake.correlationId,
+        payload: result.payload,
+      });
+    } catch (err) {
+      const errorMessage =
+        err instanceof APIError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "Unknown Mobile MCP error";
+      await sendEvent({
+        stage: "failed",
+        summary: `Failed to invoke ${handshake.toolName}`,
+        correlationId: handshake.correlationId,
+        errorMessage,
+      });
+      throw err;
+    } finally {
+      logger.info("SSE tool stream closed", {
+        sessionId: handshake.sessionId,
+        toolName: handshake.toolName,
+        correlationId: handshake.correlationId,
+      });
+    }
+  },
+);

--- a/backend/mobile-mcp/dto.ts
+++ b/backend/mobile-mcp/dto.ts
@@ -1,0 +1,188 @@
+import type { ToolInvocationResult as SdkToolInvocationResult } from "@modelcontextprotocol/sdk/types";
+
+/**
+ * MobileMcpToolName enumerates the MCP tool identifiers we expose via Encore APIs.
+ * PURPOSE: Keeps tool routing type-safe and aligned with upstream Mobile MCP server identifiers.
+ */
+export type MobileMcpToolName =
+  | "mobile_take_screenshot"
+  | "mobile_list_elements_on_screen"
+  | "mobile_click_on_screen_at_coordinates"
+  | "mobile_type_keys"
+  | "mobile_swipe_on_screen"
+  | "mobile_launch_app"
+  | "mobile_get_screen_size"
+  | "mobile_press_button"
+  | "mobile_long_press_on_screen_at_coordinates";
+
+export type MobilePlatformKind = "android" | "ios";
+
+/**
+ * StartSessionRequest captures the inputs required to allocate a Mobile MCP session.
+ * PURPOSE: Allows the agent orchestrator to request a device with optional hints when creating a session.
+ */
+export interface StartSessionRequest {
+  runId?: string;
+  platform: MobilePlatformKind;
+  deviceAlias?: string;
+  appPackageId?: string;
+  projectArnOverride?: string;
+  devicePoolArnOverride?: string;
+}
+
+/**
+ * StartSessionResponse returns identifiers and metadata for a Mobile MCP session.
+ * PURPOSE: Provides the agent with a deterministic device context token for subsequent tool invocations.
+ */
+export interface StartSessionResponse {
+  sessionId: string;
+  runId: string;
+  deviceId: string;
+  devicePlatform: MobilePlatformKind;
+  deviceFarmJobArn?: string;
+  appiumEndpointUrl?: string;
+  mcpSessionToken?: string;
+}
+
+/**
+ * ScreenshotResponse represents the normalized payload returned after invoking mobile_take_screenshot.
+ * PURPOSE: Supplies base64 image data and derived metadata to the agent perception pipeline.
+ */
+export interface ScreenshotResponse {
+  base64Image: string;
+  mimeType: "image/png" | "image/jpeg";
+  widthPx: number;
+  heightPx: number;
+  capturedAtIso: string;
+}
+
+/**
+ * ScreenDimensionsResponse exposes the device viewport size used by the agent.
+ * PURPOSE: Provides deterministic width/height metrics sourced from Mobile MCP.
+ */
+export interface ScreenDimensionsResponse {
+  widthPx: number;
+  heightPx: number;
+}
+
+/**
+ * AccessibilityNode describes a UI element derived from the Mobile MCP accessibility tool output.
+ * PURPOSE: Enables agent consumers to reason about the UI hierarchy without parsing raw MCP output.
+ */
+export interface AccessibilityNode {
+  type: string;
+  text?: string;
+  label?: string;
+  name?: string;
+  value?: string;
+  identifier?: string;
+  focused?: boolean;
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+}
+
+/**
+ * AccessibilityTreeResponse packages the tree both as structured nodes and serialized XML.
+ * PURPOSE: Supports existing XML-based downstream processors while preserving structured data.
+ */
+export interface AccessibilityTreeResponse {
+  nodes: AccessibilityNode[];
+  xml: string;
+  capturedAtIso: string;
+}
+
+/**
+ * TapRequest describes the parameters for invoking the tap MCP tool.
+ * PURPOSE: Keeps tap input type-safe when exposed via Encore APIs.
+ */
+export interface TapRequest {
+  x: number;
+  y: number;
+}
+
+/**
+ * TypeRequest encapsulates the payload needed to send text to the focused element.
+ * PURPOSE: Allows the agent to trigger text entry while controlling submit semantics.
+ */
+export interface TypeRequest {
+  text: string;
+  submit?: boolean;
+}
+
+/**
+ * SwipeRequest models a swipe gesture using start & end coordinates.
+ * PURPOSE: Enables translation into Mobile MCP direction-based swipe arguments.
+ */
+export interface SwipeRequest {
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  durationMs?: number;
+}
+
+/**
+ * LaunchAppRequest carries the package identifier required to launch the target app.
+ * PURPOSE: Provides typed data for the mobile_launch_app MCP tool.
+ */
+export interface LaunchAppRequest {
+  packageName: string;
+}
+
+/**
+ * PressButtonRequest describes a navigation button press request.
+ * PURPOSE: Enables callers to trigger system buttons such as BACK or HOME through Mobile MCP.
+ */
+export interface PressButtonRequest {
+  button: "BACK" | "HOME" | "VOLUME_UP" | "VOLUME_DOWN" | "ENTER";
+}
+
+/**
+ * LongPressRequest models a long-press gesture.
+ * PURPOSE: Enables deliberate press-and-hold interactions via Mobile MCP.
+ */
+export interface LongPressRequest {
+  x: number;
+  y: number;
+  durationMs?: number;
+}
+
+/**
+ * ToolInvocationResult captures the normalized outcome of executing a Mobile MCP tool.
+ * PURPOSE: Encodes success/error states for use by Encore endpoints and SSE streams.
+ */
+export interface ToolInvocationResult {
+  status: "SUCCEEDED" | "FAILED";
+  summary: string;
+  payload?: Record<string, unknown>;
+  errorMessage?: string;
+  rawResult?: SdkToolInvocationResult;
+}
+
+/**
+ * ToolStreamHandshake represents metadata flowing from clients when establishing the SSE bridge.
+ * PURPOSE: Conveys which tool to invoke and which arguments to forward to Mobile MCP.
+ */
+export interface ToolStreamHandshake {
+  sessionId: string;
+  toolName: MobileMcpToolName;
+  arguments?: Record<string, unknown>;
+  correlationId?: string;
+  runId?: string;
+}
+
+/**
+ * ToolStreamEvent defines the shape of SSE payloads emitted during tool execution.
+ * PURPOSE: Provides deterministic event sequencing for client listeners.
+ */
+export interface ToolStreamEvent {
+  correlationId?: string;
+  stage: "started" | "progress" | "completed" | "failed";
+  summary: string;
+  payload?: Record<string, unknown>;
+  errorMessage?: string;
+}

--- a/backend/mobile-mcp/encore.service.ts
+++ b/backend/mobile-mcp/encore.service.ts
@@ -1,0 +1,7 @@
+import { Service } from "encore.dev/service";
+
+/**
+ * MobileMcpService registers the Mobile MCP microservice within the Encore application graph.
+ * PURPOSE: Allows other services to reference the Mobile MCP endpoint group via generated clients.
+ */
+export default new Service("mobile-mcp");

--- a/backend/mobile-mcp/mobile-mcp.runtime.ts
+++ b/backend/mobile-mcp/mobile-mcp.runtime.ts
@@ -1,0 +1,146 @@
+import { createMcpServer } from "@mobilenext/mobile-mcp";
+import { Client } from "@modelcontextprotocol/sdk/client";
+import { CallToolResultSchema, type CallToolResult } from "@modelcontextprotocol/sdk/types";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory";
+import log from "encore.dev/log";
+
+/**
+ * MobileMcpRuntimeOptions define knobs required to bootstrap the in-process Mobile MCP server.
+ * PURPOSE: Allows callers to tweak runtime identity for traceability without leaking implementation details.
+ */
+export interface MobileMcpRuntimeOptions {
+  runtimeLabel?: string;
+}
+
+/**
+ * MobileMcpRuntime manages an embedded Mobile MCP server and client pair inside the Encore process.
+ * PURPOSE: Executes MCP tools without spawning external processes while preserving protocol semantics.
+ */
+export class MobileMcpRuntime {
+  private readonly logger = log.with({ module: "mobile-mcp", actor: "runtime", label: this.options.runtimeLabel });
+  private readonly server = createMcpServer();
+  private client: Client | null = null;
+  private clientTransport: InMemoryTransport | null = null;
+  private serverTransport: InMemoryTransport | null = null;
+  private initializePromise: Promise<void> | null = null;
+  private disposed = false;
+  private callChain: Promise<CallToolResult> = Promise.resolve().then(() => {
+    return {
+      content: [],
+    } satisfies CallToolResult;
+  });
+
+  constructor(private readonly options: MobileMcpRuntimeOptions = {}) {}
+
+  /**
+   * init lazily wires the in-memory transport pair between the MCP server and client.
+   * PURPOSE: Defers expensive setup until the first tool invocation while ensuring thread-safety via promise caching.
+   */
+  async init(): Promise<void> {
+    if (this.disposed) {
+      throw new Error("MobileMcpRuntime has been disposed");
+    }
+    if (this.client) {
+      return;
+    }
+    if (!this.initializePromise) {
+      this.initializePromise = this.initializeInternal();
+    }
+    await this.initializePromise;
+  }
+
+  /**
+   * callTool executes a Mobile MCP tool by name with the provided arguments.
+   * PURPOSE: Supplies a simple awaitable interface that serializes requests to guarantee determinism.
+   */
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<CallToolResult> {
+    await this.init();
+
+    const client = this.client;
+    if (!client) {
+      throw new Error("Mobile MCP client not initialized");
+    }
+
+    this.logger.debug("Invoking Mobile MCP tool", { toolName, args });
+
+    // Serialize calls to maintain deterministic order and avoid overlapping MCP request handling.
+    this.callChain = this.callChain
+      .catch(() => {
+        // Reset the chain if previous invocation failed to avoid unhandled rejections cascading.
+        return {
+          content: [],
+        } satisfies CallToolResult;
+      })
+      .then(async () => {
+        const request = {
+          method: "tools/call",
+          params: {
+            name: toolName,
+            arguments: args,
+          },
+        } as const;
+
+        const result = await client.request(request, CallToolResultSchema);
+        this.logger.debug("Mobile MCP tool result", { toolName, result });
+        return result;
+      });
+
+    return await this.callChain;
+  }
+
+  /**
+   * dispose tears down transports and releases associated resources.
+   * PURPOSE: Prevents leaking MCP transports when sessions conclude.
+   */
+  async dispose(): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+
+    try {
+      await this.clientTransport?.close();
+    } catch (err) {
+      this.logger.warn("Failed closing client transport", { err });
+    }
+
+    try {
+      await this.serverTransport?.close();
+    } catch (err) {
+      this.logger.warn("Failed closing server transport", { err });
+    }
+
+    try {
+      await this.server.close();
+    } catch (err) {
+      this.logger.warn("Failed closing Mobile MCP server", { err });
+    }
+
+    this.client = null;
+    this.clientTransport = null;
+    this.serverTransport = null;
+    this.disposed = true;
+  }
+
+  private async initializeInternal(): Promise<void> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    this.clientTransport = clientTransport;
+    this.serverTransport = serverTransport;
+
+    await this.server.connect(serverTransport);
+
+    const client = new Client(
+      {
+        name: "mobile-mcp-microservice",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    );
+
+    await client.connect(clientTransport);
+    this.client = client;
+  }
+}

--- a/backend/mobile-mcp/service.ts
+++ b/backend/mobile-mcp/service.ts
@@ -1,0 +1,565 @@
+import { ulid } from "ulidx";
+import { APIError } from "encore.dev/api";
+import log from "encore.dev/log";
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types";
+import { AwsDeviceFarmConnector } from "./aws-device-farm-connector";
+import type {
+  AccessibilityNode,
+  AccessibilityTreeResponse,
+  LaunchAppRequest,
+  MobileMcpToolName,
+  LongPressRequest,
+  PressButtonRequest,
+  ScreenDimensionsResponse,
+  ScreenshotResponse,
+  StartSessionRequest,
+  StartSessionResponse,
+  SwipeRequest,
+  TapRequest,
+  ToolInvocationResult,
+  TypeRequest,
+} from "./dto";
+import { MobileMcpRuntime } from "./mobile-mcp.runtime";
+import { MobileMcpSessionRegistry } from "./session-registry";
+
+interface SessionContext {
+  sessionId: string;
+  runId: string;
+  deviceId: string;
+  devicePlatform: "android" | "ios";
+  deviceFarmJobArn?: string | null;
+  runtime: MobileMcpRuntime;
+}
+
+/**
+ * MobileMcpOrchestrationService coordinates session lifecycle and tool execution.
+ * PURPOSE: Serves as the business layer between Encore APIs and the embedded Mobile MCP runtime.
+ */
+export class MobileMcpOrchestrationService {
+  private readonly logger = log.with({ module: "mobile-mcp", actor: "service" });
+
+  constructor(
+    private readonly registry: MobileMcpSessionRegistry,
+    private readonly connector: AwsDeviceFarmConnector,
+  ) {}
+
+  /**
+   * startSession provisions a new Mobile MCP session and persists its metadata.
+   * PURPOSE: Creates the deterministic device runtime context consumed by the agent orchestrator.
+   */
+  async startSession(request: StartSessionRequest): Promise<StartSessionResponse> {
+    const sessionId = ulid();
+    const resolvedRunId = request.runId ?? ulid();
+    const runtime = new MobileMcpRuntime({ runtimeLabel: sessionId });
+
+    const deviceDetails = await this.connector.startSession({
+      runId: resolvedRunId,
+      platform: request.platform,
+      devicePoolArnOverride: request.devicePoolArnOverride,
+      projectArnOverride: request.projectArnOverride,
+    });
+
+    await this.registry.createSession(sessionId, resolvedRunId, request.platform, deviceDetails, runtime);
+
+    const response: StartSessionResponse = {
+      sessionId,
+      runId: resolvedRunId,
+      deviceId: deviceDetails.deviceId,
+      devicePlatform: request.platform,
+      deviceFarmJobArn: deviceDetails.deviceFarmJobArn,
+      appiumEndpointUrl: deviceDetails.appiumEndpointUrl,
+      mcpSessionToken: deviceDetails.mcpSessionToken,
+    };
+
+    this.logger.info("Mobile MCP session started", {
+      sessionId,
+      runId: resolvedRunId,
+      deviceId: deviceDetails.deviceId,
+    });
+
+    return response;
+  }
+
+  /**
+   * stopSession tears down the runtime, releases Device Farm resources, and removes registry state.
+   * PURPOSE: Ensures sessions do not leak once the agent finishes interacting with the device.
+   */
+  async stopSession(sessionId: string): Promise<void> {
+    const context = this.getSessionContext(sessionId);
+    await this.connector.stopSession(context.deviceFarmJobArn ?? undefined);
+    await this.registry.removeSession(sessionId);
+    this.logger.info("Mobile MCP session stopped", { sessionId, runId: context.runId });
+  }
+
+  /**
+   * captureScreenshot executes mobile_take_screenshot and augments it with screen dimensions.
+   * PURPOSE: Supplies perception pipelines with both raw imagery and sizing information.
+   */
+  async captureScreenshot(sessionId: string): Promise<ScreenshotResponse> {
+    const context = this.getSessionContext(sessionId);
+
+    const result = await context.runtime.callTool("mobile_take_screenshot", {
+      device: context.deviceId,
+    });
+
+    if (result.isError) {
+      throw APIError.failedPrecondition(this.buildErrorMessage(result));
+    }
+
+    const imageContent = result.content?.find((item) => item.type === "image");
+    if (!imageContent || imageContent.type !== "image") {
+      throw APIError.internal("Mobile MCP screenshot response missing image content");
+    }
+
+    const screenSizeResult = await context.runtime.callTool("mobile_get_screen_size", {
+      device: context.deviceId,
+    });
+    const screenSizeText = this.extractText(screenSizeResult);
+    const dimensions = this.parseScreenSize(screenSizeText);
+    if (!dimensions) {
+      throw APIError.internal("Unable to determine screen dimensions from Mobile MCP response");
+    }
+
+    const response: ScreenshotResponse = {
+      base64Image: imageContent.data,
+      mimeType: imageContent.mimeType === "image/jpeg" ? "image/jpeg" : "image/png",
+      widthPx: dimensions.width,
+      heightPx: dimensions.height,
+      capturedAtIso: new Date().toISOString(),
+    };
+
+    await this.registry.markHeartbeat(sessionId);
+    return response;
+  }
+
+  /**
+   * getScreenDimensions returns the current viewport dimensions of the active device.
+   * PURPOSE: Allows consumers to fetch screen metrics without triggering a screenshot.
+   */
+  async getScreenDimensions(sessionId: string): Promise<ScreenDimensionsResponse> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_get_screen_size", {
+      device: context.deviceId,
+    });
+
+    if (result.isError) {
+      throw APIError.failedPrecondition(this.buildErrorMessage(result));
+    }
+
+    const dimensions = this.parseScreenSize(this.extractText(result));
+    if (!dimensions) {
+      throw APIError.internal("Unable to parse screen dimensions returned by Mobile MCP");
+    }
+
+    await this.registry.markHeartbeat(sessionId);
+    return {
+      widthPx: dimensions.width,
+      heightPx: dimensions.height,
+    };
+  }
+
+  /**
+   * fetchAccessibilityTree retrieves and normalizes the accessibility tree for the current screen.
+   * PURPOSE: Provides downstream components with structured accessibility data and an XML representation.
+   */
+  async fetchAccessibilityTree(sessionId: string): Promise<AccessibilityTreeResponse> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_list_elements_on_screen", {
+      device: context.deviceId,
+    });
+
+    if (result.isError) {
+      throw APIError.failedPrecondition(this.buildErrorMessage(result));
+    }
+
+    const treeText = this.extractText(result);
+    const nodes = this.parseAccessibilityNodes(treeText);
+    const xml = this.buildAccessibilityXml(nodes);
+
+    await this.registry.markHeartbeat(sessionId);
+    return {
+      nodes,
+      xml,
+      capturedAtIso: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * performTap dispatches a coordinate tap via Mobile MCP.
+   * PURPOSE: Bridges agent tap actions to the device session.
+   */
+  async performTap(sessionId: string, request: TapRequest): Promise<ToolInvocationResult> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_click_on_screen_at_coordinates", {
+      device: context.deviceId,
+      x: request.x,
+      y: request.y,
+    });
+    await this.registry.markHeartbeat(sessionId);
+    return this.normalizeToolResult(result, `Tapped coordinates (${request.x}, ${request.y})`);
+  }
+
+  /**
+   * performType sends text input through Mobile MCP.
+   * PURPOSE: Enables the agent to enter text programmatically on the target device.
+   */
+  async performType(sessionId: string, request: TypeRequest): Promise<ToolInvocationResult> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_type_keys", {
+      device: context.deviceId,
+      text: request.text,
+      submit: Boolean(request.submit),
+    });
+    await this.registry.markHeartbeat(sessionId);
+    return this.normalizeToolResult(result, `Typed text '${request.text}'`);
+  }
+
+  /**
+   * performSwipe translates coordinate-based swipe requests to Mobile MCP direction gestures.
+   * PURPOSE: Supports agent gestures without requiring direction-specific semantics upstream.
+   */
+  async performSwipe(sessionId: string, request: SwipeRequest): Promise<ToolInvocationResult> {
+    const context = this.getSessionContext(sessionId);
+    const swipeArguments = this.translateSwipeArguments(request);
+    const result = await context.runtime.callTool("mobile_swipe_on_screen", {
+      device: context.deviceId,
+      direction: swipeArguments.direction,
+      x: swipeArguments.x,
+      y: swipeArguments.y,
+      distance: swipeArguments.distance,
+    });
+    await this.registry.markHeartbeat(sessionId);
+    return this.normalizeToolResult(
+      result,
+      `Swiped ${swipeArguments.direction} from (${swipeArguments.x}, ${swipeArguments.y})`,
+    );
+  }
+
+  /**
+   * launchApp opens the specified package via Mobile MCP.
+   * PURPOSE: Allows the agent orchestrator to foreground the target application.
+   */
+  async launchApp(sessionId: string, request: LaunchAppRequest): Promise<ToolInvocationResult> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_launch_app", {
+      device: context.deviceId,
+      packageName: request.packageName,
+    });
+    await this.registry.markHeartbeat(sessionId);
+    return this.normalizeToolResult(result, `Launched app ${request.packageName}`);
+  }
+
+  /**
+   * pressButton submits a system button press via Mobile MCP.
+   * PURPOSE: Enables navigation actions such as BACK or HOME.
+   */
+  async pressButton(sessionId: string, request: PressButtonRequest): Promise<ToolInvocationResult> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_press_button", {
+      device: context.deviceId,
+      button: request.button,
+    });
+    await this.registry.markHeartbeat(sessionId);
+    return this.normalizeToolResult(result, `Pressed device button ${request.button}`);
+  }
+
+  /**
+   * performLongPress issues a long press gesture through Mobile MCP.
+   * PURPOSE: Enables press-and-hold interactions for context menus or drag initiations.
+   */
+  async performLongPress(sessionId: string, request: LongPressRequest): Promise<ToolInvocationResult> {
+    const context = this.getSessionContext(sessionId);
+    const result = await context.runtime.callTool("mobile_long_press_on_screen_at_coordinates", {
+      device: context.deviceId,
+      x: request.x,
+      y: request.y,
+      durationMs: request.durationMs ?? 800,
+    });
+    await this.registry.markHeartbeat(sessionId);
+    return this.normalizeToolResult(result, `Long press at (${request.x}, ${request.y})`);
+  }
+
+  /**
+   * invokeGenericTool provides a uniform representation used by the SSE bridge.
+   * PURPOSE: Allows streaming clients to consume normalized tool results across supported operations.
+   */
+  async invokeGenericTool(
+    sessionId: string,
+    toolName: MobileMcpToolName,
+    args: Record<string, unknown>,
+  ): Promise<ToolInvocationResult> {
+    switch (toolName) {
+      case "mobile_take_screenshot": {
+        const payload = await this.captureScreenshot(sessionId);
+        return {
+          status: "SUCCEEDED",
+          summary: "Screenshot captured",
+          payload,
+        };
+      }
+      case "mobile_list_elements_on_screen": {
+        const payload = await this.fetchAccessibilityTree(sessionId);
+        return {
+          status: "SUCCEEDED",
+          summary: "Accessibility tree captured",
+          payload,
+        };
+      }
+      case "mobile_get_screen_size": {
+        const payload = await this.getScreenDimensions(sessionId);
+        return {
+          status: "SUCCEEDED",
+          summary: "Screen dimensions retrieved",
+          payload,
+        };
+      }
+      case "mobile_click_on_screen_at_coordinates": {
+        const tapArgs = this.coerceTapArguments(args);
+        return await this.performTap(sessionId, tapArgs);
+      }
+      case "mobile_type_keys": {
+        const typeArgs = this.coerceTypeArguments(args);
+        return await this.performType(sessionId, typeArgs);
+      }
+      case "mobile_swipe_on_screen": {
+        const swipeArgs = this.coerceSwipeArguments(args);
+        return await this.performSwipe(sessionId, swipeArgs);
+      }
+      case "mobile_launch_app": {
+        const launchArgs = this.coerceLaunchAppArguments(args);
+        return await this.launchApp(sessionId, launchArgs);
+      }
+      case "mobile_press_button": {
+        const buttonArgs = this.coercePressButtonArguments(args);
+        return await this.pressButton(sessionId, buttonArgs);
+      }
+      case "mobile_long_press_on_screen_at_coordinates": {
+        const longPressArgs = this.coerceLongPressArguments(args);
+        return await this.performLongPress(sessionId, longPressArgs);
+      }
+      default:
+        throw APIError.invalidArgument(`Unsupported Mobile MCP tool: ${toolName}`);
+    }
+  }
+
+  private getSessionContext(sessionId: string): SessionContext {
+    const row = this.registry.getSession(sessionId);
+    const runtime = this.registry.getRuntime(sessionId);
+    if (!row || !runtime) {
+      throw APIError.notFound("Mobile MCP session not found");
+    }
+    return {
+      sessionId,
+      runId: row.runId,
+      deviceId: row.deviceId,
+      devicePlatform: row.devicePlatform,
+      deviceFarmJobArn: row.deviceFarmJobArn ?? undefined,
+      runtime,
+    };
+  }
+
+  private buildErrorMessage(result: CallToolResult): string {
+    if (!result.content?.length) {
+      return "Mobile MCP reported an error without additional details";
+    }
+    const messageParts = result.content
+      .filter((item) => item.type === "text" && item.text)
+      .map((item) => item.text as string);
+    if (!messageParts.length) {
+      return "Mobile MCP reported an error without additional details";
+    }
+    return messageParts.join(" ");
+  }
+
+  private extractText(result: CallToolResult): string {
+    if (!result.content) {
+      return "";
+    }
+    for (const item of result.content) {
+      if (item.type === "text" && item.text) {
+        return item.text;
+      }
+    }
+    return "";
+  }
+
+  private parseScreenSize(message: string): { width: number; height: number } | null {
+    const match = message.match(/(\d+)\s*x\s*(\d+)/i);
+    if (!match) {
+      return null;
+    }
+    return {
+      width: Number.parseInt(match[1], 10),
+      height: Number.parseInt(match[2], 10),
+    };
+  }
+
+  private parseAccessibilityNodes(raw: string): AccessibilityNode[] {
+    const prefix = "Found these elements on screen:";
+    const jsonSegment = raw.includes(prefix) ? raw.substring(raw.indexOf(prefix) + prefix.length).trim() : raw.trim();
+    if (!jsonSegment) {
+      return [];
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonSegment);
+    } catch (err) {
+      this.logger.warn("Failed to parse accessibility JSON payload", { err, jsonSegment });
+      throw APIError.internal("Unable to parse accessibility tree returned by Mobile MCP");
+    }
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map((value) => {
+      const element = value as Record<string, unknown>;
+      const coordinates = element.coordinates as Record<string, unknown> | undefined;
+      return {
+        type: String(element.type ?? ""),
+        text: typeof element.text === "string" ? element.text : undefined,
+        label: typeof element.label === "string" ? element.label : undefined,
+        name: typeof element.name === "string" ? element.name : undefined,
+        value: typeof element.value === "string" ? element.value : undefined,
+        identifier: typeof element.identifier === "string" ? element.identifier : undefined,
+        focused: Boolean(element.focused),
+        bounds: {
+          x: Number(coordinates?.x ?? 0),
+          y: Number(coordinates?.y ?? 0),
+          width: Number(coordinates?.width ?? 0),
+          height: Number(coordinates?.height ?? 0),
+        },
+      };
+    });
+  }
+
+  private buildAccessibilityXml(nodes: AccessibilityNode[]): string {
+    const escape = (value: string | undefined): string =>
+      value ? value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;") : "";
+
+    const elements = nodes
+      .map((node) => {
+        return `<node type="${escape(node.type)}" text="${escape(node.text)}" label="${escape(node.label)}" name="${escape(
+          node.name,
+        )}" value="${escape(node.value)}" identifier="${escape(node.identifier)}" focused="${node.focused ? "true" : "false"}" x="${
+          node.bounds.x
+        }" y="${node.bounds.y}" width="${node.bounds.width}" height="${node.bounds.height}" />`;
+      })
+      .join("");
+
+    return `<hierarchy>${elements}</hierarchy>`;
+  }
+
+  private translateSwipeArguments(request: SwipeRequest): { direction: "up" | "down" | "left" | "right"; x: number; y: number; distance: number } {
+    const deltaX = request.endX - request.startX;
+    const deltaY = request.endY - request.startY;
+    const absX = Math.abs(deltaX);
+    const absY = Math.abs(deltaY);
+
+    let direction: "up" | "down" | "left" | "right";
+    if (absX > absY) {
+      direction = deltaX >= 0 ? "right" : "left";
+    } else {
+      direction = deltaY >= 0 ? "down" : "up";
+    }
+
+    const distance = direction === "left" || direction === "right" ? absX : absY;
+
+    return {
+      direction,
+      x: request.startX,
+      y: request.startY,
+      distance,
+    };
+  }
+
+  private normalizeToolResult(result: CallToolResult, summary: string): ToolInvocationResult {
+    if (result.isError) {
+      return {
+        status: "FAILED",
+        summary,
+        errorMessage: this.buildErrorMessage(result),
+        rawResult: result,
+      };
+    }
+    const text = this.extractText(result);
+    return {
+      status: "SUCCEEDED",
+      summary,
+      payload: text ? { message: text } : undefined,
+      rawResult: result,
+    };
+  }
+
+  private coerceTapArguments(args: Record<string, unknown>): TapRequest {
+    const x = Number(args.x);
+    const y = Number(args.y);
+    if (Number.isNaN(x) || Number.isNaN(y)) {
+      throw APIError.invalidArgument("Tap requires numeric x and y coordinates");
+    }
+    return { x, y };
+  }
+
+  private coerceTypeArguments(args: Record<string, unknown>): TypeRequest {
+    const text = String(args.text ?? "");
+    const submit = Boolean(args.submit);
+    if (!text) {
+      throw APIError.invalidArgument("Type request requires text");
+    }
+    return { text, submit };
+  }
+
+  private coerceSwipeArguments(args: Record<string, unknown>): SwipeRequest {
+    const startX = Number(args.startX);
+    const startY = Number(args.startY);
+    const endX = Number(args.endX);
+    const endY = Number(args.endY);
+    if ([startX, startY, endX, endY].some((value) => Number.isNaN(value))) {
+      throw APIError.invalidArgument("Swipe request requires numeric startX, startY, endX, and endY");
+    }
+    const durationMs = args.durationMs !== undefined ? Number(args.durationMs) : undefined;
+    return {
+      startX,
+      startY,
+      endX,
+      endY,
+      durationMs,
+    };
+  }
+
+  private coerceLaunchAppArguments(args: Record<string, unknown>): LaunchAppRequest {
+    const packageName = String(args.packageName ?? "");
+    if (!packageName) {
+      throw APIError.invalidArgument("Launch app request requires packageName");
+    }
+    return { packageName };
+  }
+
+  private coercePressButtonArguments(args: Record<string, unknown>): PressButtonRequest {
+    const button = String(args.button ?? "") as PressButtonRequest["button"];
+    if (!button) {
+      throw APIError.invalidArgument("Press button request requires button");
+    }
+    return { button };
+  }
+
+  private coerceLongPressArguments(args: Record<string, unknown>): LongPressRequest {
+    const x = Number(args.x);
+    const y = Number(args.y);
+    if (Number.isNaN(x) || Number.isNaN(y)) {
+      throw APIError.invalidArgument("Long press requires numeric x and y coordinates");
+    }
+    const durationMs = args.durationMs !== undefined ? Number(args.durationMs) : undefined;
+    return { x, y, durationMs };
+  }
+}
+
+/**
+ * mobileMcpService is a singleton orchestration service used by Encore handlers.
+ * PURPOSE: Provides a shared instance with singleton dependencies.
+ */
+export const mobileMcpService = new MobileMcpOrchestrationService(
+  new MobileMcpSessionRegistry(),
+  new AwsDeviceFarmConnector(),
+);

--- a/backend/mobile-mcp/session-registry.ts
+++ b/backend/mobile-mcp/session-registry.ts
@@ -1,0 +1,156 @@
+import log from "encore.dev/log";
+
+import db from "../db";
+import type { DeviceFarmSessionDetails } from "./aws-device-farm-connector";
+import type { MobilePlatformKind } from "./dto";
+import { MobileMcpRuntime } from "./mobile-mcp.runtime";
+
+/**
+ * MobileMcpSessionRow mirrors the persisted representation in mobile_mcp_sessions.
+ * PURPOSE: Enables consistent hydration between the registry cache and the database.
+ */
+export interface MobileMcpSessionRow {
+  mobileMcpSessionId: string;
+  runId: string;
+  deviceId: string;
+  devicePlatform: MobilePlatformKind;
+  deviceFarmJobArn?: string | null;
+  appiumEndpointUrl?: string | null;
+  mcpSessionToken?: string | null;
+  status: "active" | "closed";
+  lastHeartbeatAt?: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface SessionRecord {
+  row: MobileMcpSessionRow;
+  runtime: MobileMcpRuntime;
+}
+
+/**
+ * MobileMcpSessionRegistry caches active Mobile MCP sessions for fast lookups while persisting state.
+ * PURPOSE: Guarantees deterministic session recovery if a worker restarts mid-run.
+ */
+export class MobileMcpSessionRegistry {
+  private readonly logger = log.with({ module: "mobile-mcp", actor: "session-registry" });
+  private readonly sessions = new Map<string, SessionRecord>();
+
+  /**
+   * createSession persists and caches a new Mobile MCP session record.
+   * PURPOSE: Records metadata for later tool invocations and lifecycle management.
+   */
+  async createSession(
+    sessionId: string,
+    runId: string,
+    devicePlatform: MobilePlatformKind,
+    deviceDetails: DeviceFarmSessionDetails,
+    runtime: MobileMcpRuntime,
+  ): Promise<void> {
+    const createdAt = new Date();
+    const row: MobileMcpSessionRow = {
+      mobileMcpSessionId: sessionId,
+      runId,
+      deviceId: deviceDetails.deviceId,
+      devicePlatform,
+      deviceFarmJobArn: deviceDetails.deviceFarmJobArn ?? null,
+      appiumEndpointUrl: deviceDetails.appiumEndpointUrl ?? null,
+      mcpSessionToken: deviceDetails.mcpSessionToken ?? null,
+      status: "active",
+      lastHeartbeatAt: null,
+      createdAt,
+      updatedAt: createdAt,
+    };
+
+    await db.exec`
+      INSERT INTO mobile_mcp_sessions (
+        mobile_mcp_session_id,
+        run_id,
+        device_id,
+        device_platform,
+        device_farm_job_arn,
+        appium_endpoint_url,
+        mcp_session_token,
+        status,
+        created_at,
+        updated_at
+      )
+      VALUES (
+        ${row.mobileMcpSessionId},
+        ${row.runId},
+        ${row.deviceId},
+        ${row.devicePlatform},
+        ${row.deviceFarmJobArn},
+        ${row.appiumEndpointUrl},
+        ${row.mcpSessionToken},
+        ${row.status},
+        ${row.createdAt},
+        ${row.updatedAt}
+      )
+    `;
+
+    this.sessions.set(sessionId, { row, runtime });
+    this.logger.info("Registered Mobile MCP session", { sessionId, runId, deviceId: row.deviceId });
+  }
+
+  /**
+   * getSession fetches the cached session metadata if present.
+   * PURPOSE: Allows callers to inspect device details without hitting the database.
+   */
+  getSession(sessionId: string): MobileMcpSessionRow | undefined {
+    return this.sessions.get(sessionId)?.row;
+  }
+
+  /**
+   * getRuntime retrieves the active Mobile MCP runtime associated with the session.
+   * PURPOSE: Enables tool invocation logic to execute on the correct runtime instance.
+   */
+  getRuntime(sessionId: string): MobileMcpRuntime | undefined {
+    return this.sessions.get(sessionId)?.runtime;
+  }
+
+  /**
+   * markHeartbeat updates the last heartbeat timestamp used for observability.
+   * PURPOSE: Records liveness signals so stale sessions can be cleaned up.
+   */
+  async markHeartbeat(sessionId: string): Promise<void> {
+    const record = this.sessions.get(sessionId);
+    if (!record) {
+      return;
+    }
+    const timestamp = new Date();
+    record.row.lastHeartbeatAt = timestamp;
+    record.row.updatedAt = timestamp;
+
+    await db.exec`
+      UPDATE mobile_mcp_sessions
+      SET last_heartbeat_at = ${timestamp}, updated_at = ${timestamp}
+      WHERE mobile_mcp_session_id = ${sessionId}
+    `;
+  }
+
+  /**
+   * removeSession closes and removes the session from the registry and database.
+   * PURPOSE: Ensures resources are cleaned up deterministically at the end of a run.
+   */
+  async removeSession(sessionId: string): Promise<void> {
+    const record = this.sessions.get(sessionId);
+    if (!record) {
+      return;
+    }
+
+    this.sessions.delete(sessionId);
+
+    try {
+      await record.runtime.dispose();
+    } catch (err) {
+      this.logger.warn("Error disposing Mobile MCP runtime", { err, sessionId });
+    }
+
+    await db.exec`
+      UPDATE mobile_mcp_sessions
+      SET status = 'closed', updated_at = ${new Date()}
+      WHERE mobile_mcp_session_id = ${sessionId}
+    `;
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,18 +5,22 @@
   "packageManager": "bun",
   "dependencies": {
     "@dotenvx/dotenvx": "^1.51.1",
+    "@mobilenext/mobile-mcp": "^0.0.1",
+    "@modelcontextprotocol/sdk": "^1.13.2",
     "@statelyai/inspect": "^0.4.0",
     "@types/webdriverio": "^5.0.0",
     "dotenv": "^17.2.3",
     "encore.dev": "^1.50.6",
     "envalid": "^8.1.1",
     "google-play-scraper": "^10.1.1",
+    "eventsource": "^2.0.2",
     "ulidx": "^2.4.1",
     "webdriverio": "^9.20.0",
     "xstate": "^5.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.2",
+    "@types/eventsource": "^1.1.15",
     "@types/node": "^22.0.0",
     "@wdio/appium-service": "^9.20.0",
     "@wdio/cli": "^9.20.0",


### PR DESCRIPTION
Integrate the `mobile-mcp` runtime as a new Encore microservice to replace WebDriverIO for reliable mobile device I/O and address existing Appium issues.

This PR introduces a dedicated microservice (`backend/mobile-mcp/`) running the `mobile-mcp` runtime, exposing its device interaction tools (screenshot, a11y tree, tap, type, swipe, launch app) via HTTPS and SSE endpoints. This new service is integrated with AWS Device Farm via existing Encore MCP and AWS MCP utilities. The agent's WebDriverIO adapters have been replaced with new Mobile MCP adapters to leverage this more robust and dedicated device interaction stack, aiming to resolve recent Appium-related instability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8b36691-b95e-4b58-b920-f50ca0544c1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8b36691-b95e-4b58-b920-f50ca0544c1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `mobile-mcp` Encore microservice (HTTPS + SSE) and replaces WebDriverIO with Mobile MCP adapters in the agent, with env, DB, tests, and deps updates.
> 
> - **Backend — Mobile MCP microservice**:
>   - New service in `backend/mobile-mcp/` (`encore.service.ts`, `controller.ts`, `dto.ts`).
>   - Implements in-process runtime `mobile-mcp.runtime.ts`, session registry `session-registry.ts`, and AWS Device Farm connector `aws-device-farm-connector.ts`.
>   - Exposes endpoints: `POST /mobile-mcp/sessions/start`, `DELETE /mobile-mcp/sessions/:sessionId`, tool endpoints (e.g., `mobile_take_screenshot`, `mobile_list_elements_on_screen`, `mobile_get_screen_size`, `mobile_click_on_screen_at_coordinates`, `mobile_long_press_on_screen_at_coordinates`, `mobile_swipe_on_screen`, `mobile_type_keys`, `mobile_press_button`, `mobile_launch_app`), and SSE stream `GET /mobile-mcp/sessions/:sessionId/tools/stream`.
> - **Agent integration**:
>   - Adds Mobile MCP adapters in `backend/agent/adapters/mobile-mcp/` for `session`, `perception`, `input-actions`, `navigation`, `app-lifecycle` plus lazy client loader.
>   - Updates `backend/agent/orchestrator/worker.ts` to wire new ports and remove WebDriverIO usage; extends `AgentPorts` in `backend/agent/nodes/types.ts` with `inputActionsPort` and `navigationPort`.
> - **Config & DB**:
>   - Adds env vars in `backend/config/env.ts` for AWS MCP bridge and local fallback (`MOBILE_MCP_*`).
>   - Adds migration `backend/db/migrations/010_mobile_mcp_sessions.up.sql` for `mobile_mcp_sessions` table and indexes.
> - **Tests**:
>   - Vitest for adapters: `session.adapter.test.ts`, `input-actions.adapter.test.ts` (mock `~encore/clients`).
> - **Dependencies**:
>   - Adds `@mobilenext/mobile-mcp`, `@modelcontextprotocol/sdk`, `eventsource`, and types to `backend/package.json`.
> - **Docs**:
>   - Updates `BACKEND_HANDOFF.md`; adds `backend/mobile-mcp/ARCHITECTURE.md` describing service design.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3f79d92f059cabec085e9bdf790f6b612b139c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->