### PR TITLE
chore: update bun.lock after installing encore CLI globally

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "screengraph-monorepo",


### PR DESCRIPTION
Dependencies updated during dev-log-monitoring-skill setup to fix backend startup issues. The encore CLI was installed globally to resolve PATH issues with turbo execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Regenerates `bun.lock`, adding `configVersion` and updating locked dependencies across backend and frontend workspaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cafcacfedf4690c754ba68aec6252764c7e80254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->